### PR TITLE
Fix: handle creator_id via 'attributedTo' as authors

### DIFF
--- a/src/support/rdf_activitystreams.erl
+++ b/src/support/rdf_activitystreams.erl
@@ -184,7 +184,7 @@ property_to_rdf(RscId, _Category, <<"date_end">>, Value, Context) ->
 property_to_rdf(RscId, _Category, <<"creator_id">>, CreatorId, Context) ->
     {ok, rdf_utils:resolve_triple(
         RscId,
-        namespaced_iri(endTime),
+        namespaced_iri(attributedTo),
         CreatorId,
         Context
     )};


### PR DESCRIPTION
This fixes a mistake where the `creator_id` was linked to resources in ActivityPub as its `endTime`, switching to the `attributedTo` predicate instead (which is the same used for `author` edges).